### PR TITLE
Fix O->T and T->O size in fwd open with heartbeat assemblies

### DIFF
--- a/eeip/eipclient.py
+++ b/eeip/eipclient.py
@@ -295,17 +295,18 @@ class EEIPClient:
         :param large_forward_open: Use Service code 0x58 (Large_Forward_Open) if true, otherwise 0x54 (Forward_Open)
         """
         self.__udp_client_receive_closed = False
+
+        # Default is 2 bytes offset for CIP Sequence Count, for *all*
+        # cases.  Heartbeat assemblys have no data payload but still
+        # have a CIP Sequence Count, that never changes.
         o_t_header_offset = 2
         if (self.__o_t_realtime_format == RealTimeFormat.HEADER32BIT):
             o_t_header_offset = 6
-        if (self.__o_t_realtime_format == RealTimeFormat.HEARTBEAT):
-            o_t_header_offset = 0
 
+        # Same here, 2 bytes CIP Sequence Count offset for all cases.
         t_o_header_offset = 2
         if (self.__t_o_realtime_format == RealTimeFormat.HEADER32BIT):
             t_o_header_offset = 6
-        if (self.__t_o_realtime_format == RealTimeFormat.HEARTBEAT):
-            t_o_header_offset = 0
 
         length_offset = 5 + (0 if self.__t_o_connection_type == ConnectionType.NULL else 2) + (0 if self.__o_t_connection_type == ConnectionType.NULL else 2)
 


### PR DESCRIPTION
Hi, been working on implementing a CIP adapter for a customer using the OpENer stack.

I found that OpENer rejected O->T and T->O of heartbeat assemblies.  From the little I've read and understood of CIP, heartbeat assemblies have a zero-length data payload, yet come with a CIP sequence number, that never increments (because no changes to non-existing data).  

The enclosed patch drops the code that resets the offset to 0 for heartbeats.  This works with OpENer, but may not work with other adapter implementations.